### PR TITLE
Fix string comparison with `-n`

### DIFF
--- a/command/base
+++ b/command/base
@@ -15,7 +15,7 @@ QEMU_GIT_COMMIT="49ee115552"
 # reset to blank when QEMU_REV/GIT_COMMIT bumps, otherwise begin count from 1
 QEMU_REV_ZIG_SERIAL=
 
-if [ -n $QEMU_GIT_COMMIT ]; then
+if [ -n "$QEMU_GIT_COMMIT" ]; then
     QEMU_SRC_BASENAME="${QEMU_NAME}-${QEMU_REV}-${QEMU_GIT_COMMIT}"
 else
     QEMU_SRC_BASENAME="${QEMU_NAME}-${QEMU_REV}"
@@ -34,6 +34,6 @@ WORKDIR() {
 }
 
 RUN() {
-    echo "run: $@"
+    echo "run: $*"
     "$@"
 }

--- a/command/extract
+++ b/command/extract
@@ -4,7 +4,7 @@ set -e
 
 . $(dirname $0)/base
 
-if [ -n $QEMU_GIT_COMMIT ]; then
+if [ -n "$QEMU_GIT_COMMIT" ]; then
     exit 0
 fi
 

--- a/command/fetch
+++ b/command/fetch
@@ -6,7 +6,7 @@ set -e
 
 WORKDIR /work/src
 
-if [ -n $QEMU_GIT_COMMIT ]; then
+if [ -n "$QEMU_GIT_COMMIT" ]; then
     git clone --no-checkout https://github.com/qemu/qemu.git $QEMU_SRC_BASENAME
     cd $QEMU_SRC_BASENAME
     git checkout $QEMU_GIT_COMMIT


### PR DESCRIPTION
`-n` doesn't work with unquoted arguments, it also prevents the scripts from using release when `QEMU_GIT_COMMIT` is empty.