### PR TITLE
Support for older QEMU versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@ RUN apk upgrade
 
 # required by qemu
 RUN apk add\
+ autoconf\
+ automake\
  make\
+ python2\
  python3\
  gcc\
  libc-dev\
+ libtool\
  pkgconf\
  linux-headers\
  glib-dev glib-static\

--- a/command/patch
+++ b/command/patch
@@ -5,4 +5,4 @@ set -e
 . $(dirname $0)/base
 
 WORKDIR "/work/src/${QEMU_SRC_BASENAME}"
-RUN patch -p1 -i "${WORK_ROOT}/patch/qemu.diff"
+RUN patch -p1 --forward -i "${WORK_ROOT}/patch/qemu.diff"

--- a/patch/qemu.diff
+++ b/patch/qemu.diff
@@ -56,3 +56,18 @@ index 6495ddc4..debb6f33 100644
      struct target_sigevent *target_sevp;
  
      if (!lock_user_struct(VERIFY_READ, target_sevp, target_addr, 1)) {
+diff --git a/util/memfd.c b/util/memfd.c
+index 00334e5b21..4a3c07e0be 100644
+--- a/util/memfd.c
++++ b/util/memfd.c
+@@ -35,7 +35,7 @@
+ #include <sys/syscall.h>
+ #include <asm/unistd.h>
+ 
+-static int memfd_create(const char *name, unsigned int flags)
++int memfd_create(const char *name, unsigned int flags)
+ {
+ #ifdef __NR_memfd_create
+     return syscall(__NR_memfd_create, name, flags);
+-- 
+


### PR DESCRIPTION
Support building old versions of QEMU as well - I was able to build 2.10.2 version, for example, together with https://github.com/ziglang/qemu-static/pull/5

Added one `util/memfd.c` patch because old QEMU failed to be built without this, but it was applied since 4.2.0, so added `--forward` option to `command/patch` to skip if already applied.