### PR TITLE
add ci workflow to build on linux x86_64 and aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build QEMU Static Binaries
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+  release:
+    types: [created]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: x86_64
+            runs-on: ubuntu-latest
+          - name: aarch64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx (for multi-arch)
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: |
+          docker build --tag qemu .
+
+      - name: Run container and copy artifacts
+        run: |
+          mkdir -p artifact
+          docker run --cidfile=qemu.cid qemu true
+          docker cp "$(cat qemu.cid):/work/artifact/." artifact/.
+
+      - name: Upload QEMU binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: qemu-static-binaries-${{ matrix.name }}
+          path: artifact/*
+
+      - name: Upload binaries to GitHub Release
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifact/*


### PR DESCRIPTION
I added a CI workflow that does the qemu-static build steps using GitHub Actions runners, figured I'd open a PR to offer it here upstream in case there's interest in it.

* Builds qemu-static userspace binaries for x86_64 and aarch64 Linux
* For releases, uploads the built artifacts to the release
* workflow_dispatch that allows testing builds in branches without doing a release or committing to the master/main branch

I also have "main" listed as a trigger that can be removed if desired, or if you ever rename your branch from "master" to "main" then no changes would be needed to this workflow. (I was testing on a branch named "main" in my fork, which will have some other changes that diverge from this repository).